### PR TITLE
Always close file in read_text_file

### DIFF
--- a/configuru.hpp
+++ b/configuru.hpp
@@ -3027,6 +3027,7 @@ namespace configuru
 		fseek(fp, 0, SEEK_END);
 		auto size = ftell(fp);
 		if (size < 0) {
+			fclose(fp);
 			CONFIGURU_ONERROR(std::string("Failed to find out size of '") + path + "': " + strerror(errno));
 		}
 		contents.resize(static_cast<size_t>(size));

--- a/configuru.hpp
+++ b/configuru.hpp
@@ -3025,14 +3025,14 @@ namespace configuru
 		}
 		std::string contents;
 		fseek(fp, 0, SEEK_END);
-		auto size = ftell(fp);
+		const auto size = ftell(fp);
 		if (size < 0) {
 			fclose(fp);
 			CONFIGURU_ONERROR(std::string("Failed to find out size of '") + path + "': " + strerror(errno));
 		}
 		contents.resize(static_cast<size_t>(size));
 		rewind(fp);
-		auto num_read = fread(&contents[0], 1, contents.size(), fp);
+		const auto num_read = fread(&contents[0], 1, contents.size(), fp);
 		fclose(fp);
 		if (num_read != contents.size()) {
 			CONFIGURU_ONERROR(std::string("Failed to read from '") + path + "': " + strerror(errno));


### PR DESCRIPTION
`cppcheck` found a place where a filepointer might not be closed properly. This pr fixes that.