### PR TITLE
Bug fix in deep_eq when comparing arrays

### DIFF
--- a/configuru.hpp
+++ b/configuru.hpp
@@ -1787,7 +1787,7 @@ namespace configuru
 			auto&& b_array = b.as_array();
 			if (a_array.size() != b_array.size()) { return false; }
 			for (size_t i=0; i<a_array.size(); ++i) {
-				if (!deep_eq(a_array[i], a_array[i])) {
+				if (!deep_eq(a_array[i], b_array[i])) {
 					return false;
 				}
 			}


### PR DESCRIPTION
Fixes a bug in `Config::deep_eq` when comparing arrays.

It would probably be good to add a unit test to cover this, but I'm not sure how to do that.